### PR TITLE
Use numpy to improve performance

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,20 @@
+# API Reference
+
+This section provides detailed documentation for the Baccarat API.
+
+## Overview
+
+Baccarat is a framework for running Monte Carlo simulations using NumPy. It provides:
+
+- A base `Simulator` class for implementing custom simulations
+- Parameter descriptors that generate random values according to specific distributions
+- Vectorized operations for high performance
+
+## Module Structure
+
+- [`simulator`](simulator.md): Contains the `Simulator` base class
+- [`params`](params/index.md): Contains parameter descriptor classes for simulations
+  - [`params.base`](params/base.md): Base parameter class
+  - [`params.gaussian`](params/gaussian.md): Gaussian distribution parameters
+  - [`params.uniform`](params/uniform.md): Uniform distribution parameters
+  - [`params.static`](params/static.md): Static (fixed) parameters

--- a/docs/api/params/base.md
+++ b/docs/api/params/base.md
@@ -1,0 +1,53 @@
+# Base Parameter
+
+`baccarat.params.Param`
+
+## Overview
+
+The `Param` class is an abstract base class that defines the interface for all parameter types. It implements Python's descriptor protocol to automatically generate new random values when accessed within a `Simulator` instance.
+
+## Class Definition
+
+```python
+class Param(ABC):
+    def __get__(self, instance, owner):
+        # Generate a new value each time the parameter is accessed
+        return self.generate(rng=instance.rng, num_generated=instance.num_samples)
+
+    @abstractmethod
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        """
+        Generate random values using the given random number generator.
+        
+        Args:
+            rng: The NumPy random number generator to use
+            num_generated: Number of values to generate
+            
+        Returns:
+            np.ndarray: Array of generated values
+        """
+```
+
+## Descriptor Protocol
+
+The `Param` class uses Python's descriptor protocol to provide dynamic behavior when parameters are accessed as instance attributes in a `Simulator` subclass:
+
+1. When a parameter is accessed (e.g., `self.x` in a `Simulator` subclass), Python calls the `__get__` method
+2. The `__get__` method calls the `generate` method with the simulator's random number generator and sample count
+3. The `generate` method returns an array of random values according to the parameter's specific distribution
+
+## Custom Parameter Types
+
+To create a custom parameter type, subclass `Param` and implement the `generate` method:
+
+```python
+import numpy as np
+from baccarat.params import Param
+
+class ExponentialParam(Param):
+    def __init__(self, scale=1.0):
+        self.scale = scale
+        
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        return rng.exponential(scale=self.scale, size=num_generated)
+```

--- a/docs/api/params/gaussian.md
+++ b/docs/api/params/gaussian.md
@@ -1,0 +1,53 @@
+# Gaussian Parameter
+
+`baccarat.params.GaussianParam`
+
+## Overview
+
+The `GaussianParam` class generates random values from a Gaussian (normal) distribution. It is a concrete implementation of the [`Param`](base.md) abstract base class.
+
+## Class Definition
+
+```python
+class GaussianParam(Param):
+    def __init__(self, mean: float, std: float):
+        """
+        Initialize a Gaussian parameter.
+        
+        Args:
+            mean: The mean (average) of the distribution
+            std: The standard deviation of the distribution
+        """
+        self.mean = mean
+        self.std = std
+
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        """
+        Generate random values from a Gaussian distribution.
+        
+        Args:
+            rng: The NumPy random number generator to use
+            num_generated: Number of values to generate
+            
+        Returns:
+            np.ndarray: Array of random values from the Gaussian distribution
+        """
+        return rng.normal(self.mean, self.std, size=num_generated)
+```
+
+## Usage
+
+```python
+from baccarat import Simulator, GaussianParam
+
+class MySimulator(Simulator):
+    # Create a Gaussian parameter with mean 0 and standard deviation 1
+    x = GaussianParam(mean=0.0, std=1.0)
+    
+    def simulation(self):
+        # Access the parameter to get an array of gaussian random values
+        values = self.x
+        
+        # Perform calculations with these values
+        return values ** 2
+```

--- a/docs/api/params/index.md
+++ b/docs/api/params/index.md
@@ -1,0 +1,45 @@
+# Parameters
+
+`baccarat.params`
+
+## Overview
+
+The `params` module provides parameter descriptor classes for use with the `Simulator` class. These parameters automatically generate random values according to specific distributions when accessed within a simulation.
+
+## Base Class
+
+All parameter types inherit from the [`Param`](base.md) abstract base class, which defines the common interface.
+
+## Parameter Types
+
+| Class | Description |
+|-------|-------------|
+| [`GaussianParam`](gaussian.md) | Generates random values from a Gaussian (normal) distribution |
+| [`UniformParam`](uniform.md) | Generates random values from a uniform distribution |
+| [`StaticParam`](static.md) | Provides a fixed, constant value |
+
+## Usage
+
+Parameters are defined as class variables in a `Simulator` subclass:
+
+```python
+from baccarat import Simulator, GaussianParam, UniformParam, StaticParam
+
+class MySimulator(Simulator):
+    # Parameters are defined as class variables
+    x = UniformParam(0.0, 10.0)
+    y = GaussianParam(mean=5.0, std=2.0)
+    z = StaticParam(3.14159)
+    
+    def simulation(self):
+        # Access parameters to get arrays of random values
+        x_values = self.x  # Array of uniform random values
+        y_values = self.y  # Array of gaussian random values
+        z_values = self.z  # Array filled with the constant value
+        
+        # Perform calculations with these arrays
+        result = x_values * y_values + z_values
+        return result
+```
+
+The parameters use Python's descriptor protocol to generate new random values each time they are accessed.

--- a/docs/api/params/static.md
+++ b/docs/api/params/static.md
@@ -1,0 +1,61 @@
+# Static Parameter
+
+`baccarat.params.StaticParam`
+
+## Overview
+
+The `StaticParam` class provides a fixed, constant value as an array. It is a concrete implementation of the [`Param`](base.md) abstract base class.
+
+## Class Definition
+
+```python
+class StaticParam(Param):
+    def __init__(self, value):
+        """
+        Initialize a static parameter.
+        
+        Args:
+            value: The fixed value to use for all elements
+        """
+        self.value = value
+
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        """
+        Generate an array filled with the constant value.
+        
+        Args:
+            rng: The NumPy random number generator (not used)
+            num_generated: Number of elements in the array
+            
+        Returns:
+            np.ndarray: Array filled with the constant value
+        """
+        return self.value * np.ones(num_generated)
+```
+
+## Usage
+
+```python
+from baccarat import Simulator, UniformParam, StaticParam
+
+class GravitySimulator(Simulator):
+    # Random initial height (0-100 meters)
+    height = UniformParam(0.0, 100.0)
+    
+    # Constant gravitational acceleration (9.81 m/s²)
+    gravity = StaticParam(9.81)
+    
+    def simulation(self):
+        # Calculate time to hit ground: t = sqrt(2h/g)
+        heights = self.height
+        g = self.gravity
+        
+        # Return array of fall times
+        return np.sqrt(2 * heights / g)
+```
+
+## Notes
+
+- The `StaticParam` creates an array where every element has the same value
+- Unlike other parameter types, it does not use the random number generator
+- Useful for physical constants or other fixed values in simulations

--- a/docs/api/params/uniform.md
+++ b/docs/api/params/uniform.md
@@ -1,0 +1,54 @@
+# Uniform Parameter
+
+`baccarat.params.UniformParam`
+
+## Overview
+
+The `UniformParam` class generates random values from a uniform distribution. It is a concrete implementation of the [`Param`](base.md) abstract base class.
+
+## Class Definition
+
+```python
+class UniformParam(Param):
+    def __init__(self, low: float = 0.0, high: float = 1.0):
+        """
+        Initialize a uniform parameter.
+        
+        Args:
+            low: Lower bound of the distribution (inclusive)
+            high: Upper bound of the distribution (exclusive)
+        """
+        self.low = low
+        self.high = high
+
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        """
+        Generate random values from a uniform distribution.
+        
+        Args:
+            rng: The NumPy random number generator to use
+            num_generated: Number of values to generate
+            
+        Returns:
+            np.ndarray: Array of random values from the uniform distribution
+        """
+        return rng.uniform(self.low, self.high, size=num_generated)
+```
+
+## Usage
+
+```python
+from baccarat import Simulator, UniformParam
+
+class DiceRollSimulator(Simulator):
+    # Create a uniform parameter for dice rolls (1-6)
+    # Note: We use 0.5 to 6.5 to get a uniform distribution over integers 1-6
+    roll = UniformParam(low=0.5, high=6.5)
+    
+    def simulation(self):
+        # Get array of random dice rolls
+        rolls = self.roll
+        
+        # Convert to integers (1-6)
+        return np.floor(rolls).astype(int)
+```

--- a/docs/api/simulator.md
+++ b/docs/api/simulator.md
@@ -1,0 +1,106 @@
+# Simulator
+
+`baccarat.simulator.Simulator`
+
+## Overview
+
+The `Simulator` class is the core of the Baccarat framework. It provides the foundation for implementing Monte Carlo simulations with vectorized operations via NumPy.
+
+## Class Definition
+
+```python
+class Simulator(ABC):
+    def __init__(self, num_samples: int):
+        """
+        Initialize a simulator for Monte Carlo simulations.
+        
+        Args:
+            num_samples: Number of simulation samples to generate
+        """
+```
+
+## Methods
+
+### `simulation`
+
+```python
+@abstractmethod
+def simulation(self):
+    """
+    Logic for a single simulation.
+    
+    This method must be implemented by subclasses and contains the core simulation logic.
+    The method should return a NumPy array of results.
+    
+    Returns:
+        np.ndarray: Array of simulation results
+    """
+```
+
+### `compile_results`
+
+```python
+def compile_results(self) -> Any:
+    """
+    Compile the results of the simulations.
+    
+    Post-processing of the results after all simulations have been completed.
+    By default, this method simply returns the results array.
+    
+    Returns:
+        Any: Processed simulation results
+    """
+```
+
+### `run`
+
+```python
+def run(self):
+    """
+    Main entry point to execute the simulation.
+    
+    Runs the simulation and compiles the results.
+    
+    Returns:
+        Any: The compiled simulation results
+    """
+```
+
+## Properties
+
+- `num_samples`: Number of simulation samples
+- `results`: NumPy array storing simulation results
+- `rng`: NumPy random number generator
+
+## Usage
+
+To create a custom simulation, subclass `Simulator` and implement the `simulation` method:
+
+```python
+import numpy as np
+from baccarat import Simulator, UniformParam
+
+class PiEstimator(Simulator):
+    x = UniformParam(-1.0, 1.0)
+    y = UniformParam(-1.0, 1.0)
+    
+    def simulation(self):
+        # Get random points in a square
+        x = self.x
+        y = self.y
+        
+        # Check if points are inside the unit circle
+        inside_circle = x**2 + y**2 <= 1.0
+        
+        # Return array of boolean values (inside circle = True)
+        return inside_circle
+    
+    def compile_results(self):
+        # Calculate pi estimation: (points inside circle / total points) * 4
+        return 4.0 * np.mean(self.results)
+
+# Create and run simulation
+simulator = PiEstimator(num_samples=1000000)
+pi_estimate = simulator.run()
+print(f"Pi estimate: {pi_estimate}")
+```

--- a/examples/gamma_rays_cs/gamma_rays_cs.py
+++ b/examples/gamma_rays_cs/gamma_rays_cs.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy as np
+
 from baccarat import Simulator, UniformParam, StaticParam, GaussianParam
 
 
@@ -12,22 +14,28 @@ class GammaRaySim(Simulator):
 
     def __init__(self, num_samples: int, max_workers: int | None = None):
         super().__init__(num_samples, max_workers)
-        self.energy_mev = self.initial_energy_mev
+        self.energy_mev = np.empty(num_samples)
 
     def simulation(self):
-        self.energy_mev = self.initial_energy_mev
-        scatter_probability = self.scatter_probability
-
-        # Compton scattering condition
-        if scatter_probability < self.get_scatter_probability():
-            scatter_angle_determined = False
-            while not scatter_angle_determined:
-                theta = self.scattering_angle
-                scatter_angle_determined = self.scattering_angle_outcome < self.probability_klein_nishina(theta)
-            self.compton_scatter_energy(theta)
-            energy_mev = self.initial_energy_mev - self.energy_mev
-        else:
-            energy_mev = self.energy_mev
+        # Get initial parameters as numpy arrays
+        initial_energy = self.initial_energy_mev
+        scatter_prob = self.scatter_probability
+        scatter_angles = self.scattering_angle
+        scatter_outcome = self.scattering_angle_outcome
+        
+        # Update energy_mev to match the shape of initial_energy
+        self.energy_mev = initial_energy.copy()
+        
+        # Get scattering angles and energies
+        theta = self.get_scattering_angles(scatter_outcome, scatter_angles)
+        scatter_energies = self.compton_scatter_energy(theta)
+        
+        # Calculate final energy
+        energy_mev = np.where(
+            scatter_prob < self.get_scatter_probability(), 
+            initial_energy - scatter_energies, 
+            initial_energy
+        )
 
         return energy_mev
 
@@ -38,21 +46,58 @@ class GammaRaySim(Simulator):
     def alpha(self):
         return self.energy_mev / 0.511
 
-    def probability_compton_scatter(self):
+    def probability_compton_scatter(self) -> np.ndarray:
         """Probability of Compton scattering."""
-        return 1.04713 * math.exp(0.23 * math.exp(-0.5 * self.energy_mev))
+        return 1.04713 * np.exp(0.23 * np.exp(-0.5 * self.energy_mev))
 
-    def probability_photoelectic_absorption(self) -> float:
+    def probability_photoelectic_absorption(self) -> np.ndarray:
         """Probability of photoelectric absorption."""
-        return 1.01158 * 10**(132 * math.exp(-28 * self.energy_mev))
+        return 1.01158 * 10**(132 * np.exp(-28 * self.energy_mev))
 
-    def get_scatter_probability(self) -> float:
+    def get_scatter_probability(self) -> np.ndarray:
         """Probability of scattering."""
         p_scatter = self.probability_compton_scatter()
         p_absorb = self.probability_photoelectic_absorption()
         return p_scatter / (p_scatter + p_absorb)
+        
+    def get_scattering_angles(self, initial_scatter_outcomes: np.ndarray, initial_scatter_angles: np.ndarray) -> np.ndarray:
+        """Returns the scattering angles."""
+        angles = initial_scatter_angles.copy()
+        outcomes = initial_scatter_outcomes.copy()
+        
+        # Get the Klein-Nishina probability for all angles
+        klein_nishina_probs = self.probability_klein_nishina(angles)
+        
+        # Find indices where outcome is greater than or equal to Klein-Nishina probability
+        invalid_mask = outcomes >= klein_nishina_probs
+        
+        if not np.any(invalid_mask):
+            return angles
+        
+        # Process invalid indices in a vectorized way
+        max_iterations = 50  # Prevent infinite loops
+        
+        for _ in range(max_iterations):
+            if not np.any(invalid_mask):
+                break
+                
+            # Generate new angles and outcomes only for invalid points
+            new_angles = self.rng.uniform(0, 2*math.pi, size=np.sum(invalid_mask))
+            new_outcomes = self.rng.uniform(0, 1, size=np.sum(invalid_mask))
+            
+            # Update the invalid elements
+            angles[invalid_mask] = new_angles
+            outcomes[invalid_mask] = new_outcomes
+            
+            # Recalculate Klein-Nishina probabilities
+            klein_nishina_probs = self.probability_klein_nishina(angles)
+            
+            # Update the invalid mask
+            invalid_mask = outcomes >= klein_nishina_probs
+        
+        return angles
 
-    def compton_scatter_energy(self, theta: float) -> None:
+    def compton_scatter_energy(self, theta: np.ndarray) -> np.ndarray:
         """
         Sets the energy to the new energy of the scattered photon.
 
@@ -62,11 +107,11 @@ class GammaRaySim(Simulator):
         Returns:
             float: The new energy of the scattered photon.
         """
-        self.energy_mv = self.energy_mev / (1 + self.alpha * (1 - math.cos(theta)))
-
-    def probability_klein_nishina(self, theta: float) -> float:
+        return self.energy_mev / (1 + (self.alpha) * (1 - np.cos(theta)))
+        
+    def probability_klein_nishina(self, theta: np.ndarray) -> np.ndarray:
         """Probability that the photon is scattered at some angle."""
-        cos_theta = math.cos(theta)
+        cos_theta = np.cos(theta)
         a = 1 / (1 + self.alpha * (1 - cos_theta))
         b = (1 + cos_theta**2) / 2
         c = self.alpha**2 * (1 - cos_theta**2)
@@ -74,12 +119,12 @@ class GammaRaySim(Simulator):
         return a**2 * b * (1 + c / d)
 
     # This function is used in the "large detector regime" (not simulated here)
-    def smear(self) -> float:
+    def smear(self) -> np.ndarray:
         return self.energy_mev + 0.01 * self.energy_mev * self.energy_smear_factor
 
 
 if __name__ == "__main__":
-    sim = GammaRaySim(10_000)
+    sim = GammaRaySim(1_000_000)
     res = sim.run()
     # Try adding a histogram of the results yourself!
     print("First ten results:")

--- a/examples/gamma_rays_cs/gamma_rays_cs.py
+++ b/examples/gamma_rays_cs/gamma_rays_cs.py
@@ -12,8 +12,8 @@ class GammaRaySim(Simulator):
     scattering_angle_outcome = UniformParam(0, 1)
     energy_smear_factor = GaussianParam(0, 1)
 
-    def __init__(self, num_samples: int, max_workers: int | None = None):
-        super().__init__(num_samples, max_workers)
+    def __init__(self, num_samples: int):
+        super().__init__(num_samples)
         self.energy_mev = np.empty(num_samples)
 
     def simulation(self):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,12 @@ nav:
     - Quick Start: quickstart.md
     - Tutorials:
       - Tutorial 1 - Approximating Pi: tutorials/example1.md
+    - API Reference:
+      - Overview: api/index.md
+      - Simulator: api/simulator.md
+      - Parameters:
+        - Overview: api/params/index.md
+        - Base Parameter: api/params/base.md
+        - Gaussian Parameter: api/params/gaussian.md
+        - Uniform Parameter: api/params/uniform.md
+        - Static Parameter: api/params/static.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
     { name = "Mathias Alexander", email = "mathias@mathias-alexander.com" }
 ]
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "numpy>=2.2.3",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/baccarat/params/base.py
+++ b/src/baccarat/params/base.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Any  
+import numpy as np
 
 class Param(ABC):
         
     def __get__(self, instance, owner):
         # Generate a new value each time the parameter is accessed
-        return self.generate()
+        return self.generate(rng=instance.rng, num_generated=instance.num_samples)
 
     @abstractmethod
-    def generate(self) -> Any:
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
         raise NotImplementedError("Subclasses must implement generate method")

--- a/src/baccarat/params/gaussian.py
+++ b/src/baccarat/params/gaussian.py
@@ -1,4 +1,4 @@
-import random
+import numpy as np
 
 from .base import Param
 
@@ -8,5 +8,5 @@ class GaussianParam(Param):
         self.mean = mean
         self.std = std
 
-    def generate(self) -> float:
-        return random.gauss(self.mean, self.std)
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        return rng.normal(self.mean, self.std, size=num_generated)

--- a/src/baccarat/params/static.py
+++ b/src/baccarat/params/static.py
@@ -1,8 +1,10 @@
+import numpy as np
+
 from .base import Param
 
 class StaticParam(Param):
     def __init__(self, value):
         self.value = value
 
-    def generate(self):
-        return self.value
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        return self.value * np.ones(num_generated)

--- a/src/baccarat/params/uniform.py
+++ b/src/baccarat/params/uniform.py
@@ -1,4 +1,4 @@
-import random
+import numpy as np
 
 from .base import Param
 
@@ -7,5 +7,5 @@ class UniformParam(Param):
         self.low = low
         self.high = high
 
-    def generate(self) -> float:
-        return random.uniform(self.low, self.high)
+    def generate(self, rng: np.random.Generator, num_generated: int) -> np.ndarray:
+        return rng.uniform(self.low, self.high, size=num_generated)

--- a/src/baccarat/simulator.py
+++ b/src/baccarat/simulator.py
@@ -1,13 +1,11 @@
-import multiprocessing
 from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
 
 class Simulator(ABC):
-    def __init__(self, num_samples: int, max_workers: int | None = None):
+    def __init__(self, num_samples: int):
         self.num_samples = num_samples
-        self.max_workers = max_workers or multiprocessing.cpu_count()  # Assume simulation is CPU-bound
         self.results: np.ndarray = np.empty(num_samples)
         self.rng = np.random.default_rng()
         

--- a/src/baccarat/simulator.py
+++ b/src/baccarat/simulator.py
@@ -1,14 +1,15 @@
 import multiprocessing
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import numpy as np
 
 class Simulator(ABC):
     def __init__(self, num_samples: int, max_workers: int | None = None):
         self.num_samples = num_samples
         self.max_workers = max_workers or multiprocessing.cpu_count()  # Assume simulation is CPU-bound
-        self.results: list = []
+        self.results: np.ndarray = np.empty(num_samples)
+        self.rng = np.random.default_rng()
         
     @abstractmethod
     def simulation(self):
@@ -26,12 +27,6 @@ class Simulator(ABC):
     
     def run(self):
         """Main entry point to execute the simulation."""
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            self.results = list(executor.map(self._simulation_wrapper, range(self.num_samples)))
+        self.results = self.simulation()
         return self.compile_results()
-        
-    def _simulation_wrapper(self, _):
-        """Helper for a compatible interface with mapping in the ThreadPoolExecutor of `run`."""
-        return self.simulation()
-    
     

--- a/uv.lock
+++ b/uv.lock
@@ -5,6 +5,9 @@ requires-python = ">=3.13"
 name = "baccarat"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -16,6 +19,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "numpy", specifier = ">=2.2.3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -202,6 +206,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/90/8956572f5c4ae52201fdec7ba2044b2c882832dcec7d5d0922c9e9acf2de/numpy-2.2.3.tar.gz", hash = "sha256:dbdc15f0c81611925f382dfa97b3bd0bc2c1ce19d4fe50482cb0ddc12ba30020", size = 20262700 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/8b/88b98ed534d6a03ba8cddb316950fe80842885709b58501233c29dfa24a9/numpy-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bfdb06b395385ea9b91bf55c1adf1b297c9fdb531552845ff1d3ea6e40d5aba", size = 20916001 },
+    { url = "https://files.pythonhosted.org/packages/d9/b4/def6ec32c725cc5fbd8bdf8af80f616acf075fe752d8a23e895da8c67b70/numpy-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23c9f4edbf4c065fddb10a4f6e8b6a244342d95966a48820c614891e5059bb50", size = 14130721 },
+    { url = "https://files.pythonhosted.org/packages/20/60/70af0acc86495b25b672d403e12cb25448d79a2b9658f4fc45e845c397a8/numpy-2.2.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:a0c03b6be48aaf92525cccf393265e02773be8fd9551a2f9adbe7db1fa2b60f1", size = 5130999 },
+    { url = "https://files.pythonhosted.org/packages/2e/69/d96c006fb73c9a47bcb3611417cf178049aae159afae47c48bd66df9c536/numpy-2.2.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:2376e317111daa0a6739e50f7ee2a6353f768489102308b0d98fcf4a04f7f3b5", size = 6665299 },
+    { url = "https://files.pythonhosted.org/packages/5a/3f/d8a877b6e48103733ac224ffa26b30887dc9944ff95dffdfa6c4ce3d7df3/numpy-2.2.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fb62fe3d206d72fe1cfe31c4a1106ad2b136fcc1606093aeab314f02930fdf2", size = 14064096 },
+    { url = "https://files.pythonhosted.org/packages/e4/43/619c2c7a0665aafc80efca465ddb1f260287266bdbdce517396f2f145d49/numpy-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52659ad2534427dffcc36aac76bebdd02b67e3b7a619ac67543bc9bfe6b7cdb1", size = 16114758 },
+    { url = "https://files.pythonhosted.org/packages/d9/79/ee4fe4f60967ccd3897aa71ae14cdee9e3c097e3256975cc9575d393cb42/numpy-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b416af7d0ed3271cad0f0a0d0bee0911ed7eba23e66f8424d9f3dfcdcae1304", size = 15259880 },
+    { url = "https://files.pythonhosted.org/packages/fb/c8/8b55cf05db6d85b7a7d414b3d1bd5a740706df00bfa0824a08bf041e52ee/numpy-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1402da8e0f435991983d0a9708b779f95a8c98c6b18a171b9f1be09005e64d9d", size = 17876721 },
+    { url = "https://files.pythonhosted.org/packages/21/d6/b4c2f0564b7dcc413117b0ffbb818d837e4b29996b9234e38b2025ed24e7/numpy-2.2.3-cp313-cp313-win32.whl", hash = "sha256:136553f123ee2951bfcfbc264acd34a2fc2f29d7cdf610ce7daf672b6fbaa693", size = 6290195 },
+    { url = "https://files.pythonhosted.org/packages/97/e7/7d55a86719d0de7a6a597949f3febefb1009435b79ba510ff32f05a8c1d7/numpy-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5b732c8beef1d7bc2d9e476dbba20aaff6167bf205ad9aa8d30913859e82884b", size = 12619013 },
+    { url = "https://files.pythonhosted.org/packages/a6/1f/0b863d5528b9048fd486a56e0b97c18bf705e88736c8cea7239012119a54/numpy-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:435e7a933b9fda8126130b046975a968cc2d833b505475e588339e09f7672890", size = 20944621 },
+    { url = "https://files.pythonhosted.org/packages/aa/99/b478c384f7a0a2e0736177aafc97dc9152fc036a3fdb13f5a3ab225f1494/numpy-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7678556eeb0152cbd1522b684dcd215250885993dd00adb93679ec3c0e6e091c", size = 14142502 },
+    { url = "https://files.pythonhosted.org/packages/fb/61/2d9a694a0f9cd0a839501d362de2a18de75e3004576a3008e56bdd60fcdb/numpy-2.2.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2e8da03bd561504d9b20e7a12340870dfc206c64ea59b4cfee9fceb95070ee94", size = 5176293 },
+    { url = "https://files.pythonhosted.org/packages/33/35/51e94011b23e753fa33f891f601e5c1c9a3d515448659b06df9d40c0aa6e/numpy-2.2.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:c9aa4496fd0e17e3843399f533d62857cef5900facf93e735ef65aa4bbc90ef0", size = 6691874 },
+    { url = "https://files.pythonhosted.org/packages/ff/cf/06e37619aad98a9d03bd8d65b8e3041c3a639be0f5f6b0a0e2da544538d4/numpy-2.2.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4ca91d61a4bf61b0f2228f24bbfa6a9facd5f8af03759fe2a655c50ae2c6610", size = 14036826 },
+    { url = "https://files.pythonhosted.org/packages/0c/93/5d7d19955abd4d6099ef4a8ee006f9ce258166c38af259f9e5558a172e3e/numpy-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:deaa09cd492e24fd9b15296844c0ad1b3c976da7907e1c1ed3a0ad21dded6f76", size = 16096567 },
+    { url = "https://files.pythonhosted.org/packages/af/53/d1c599acf7732d81f46a93621dab6aa8daad914b502a7a115b3f17288ab2/numpy-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:246535e2f7496b7ac85deffe932896a3577be7af8fb7eebe7146444680297e9a", size = 15242514 },
+    { url = "https://files.pythonhosted.org/packages/53/43/c0f5411c7b3ea90adf341d05ace762dad8cb9819ef26093e27b15dd121ac/numpy-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:daf43a3d1ea699402c5a850e5313680ac355b4adc9770cd5cfc2940e7861f1bf", size = 17872920 },
+    { url = "https://files.pythonhosted.org/packages/5b/57/6dbdd45ab277aff62021cafa1e15f9644a52f5b5fc840bc7591b4079fb58/numpy-2.2.3-cp313-cp313t-win32.whl", hash = "sha256:cf802eef1f0134afb81fef94020351be4fe1d6681aadf9c5e862af6602af64ef", size = 6346584 },
+    { url = "https://files.pythonhosted.org/packages/97/9b/484f7d04b537d0a1202a5ba81c6f53f1846ae6c63c2127f8df869ed31342/numpy-2.2.3-cp313-cp313t-win_amd64.whl", hash = "sha256:aee2512827ceb6d7f517c8b85aa5d3923afe8fc7a57d028cffcd522f1c6fd082", size = 12706784 },
 ]
 
 [[package]]


### PR DESCRIPTION
Use vectorized computations on NumPy arrays to dramatically improve performance.  No more multithreaded needed. Improvement to performance was so drastic, it was painfully obvious and no quantitative benchmarking was performed comparing the implementations before and after optimization.

This change introduces a slight decrease in ease of use and reasoning about the simulation, but the performance benefit is outsized comparatively.

Simple examples, like estimating pi are exactly the same.